### PR TITLE
Feature/Add-keycloak-to-docker-compose-development-environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,20 @@ services:
       PGADMIN_DEFAULT_PASSWORD: root
     ports:
       - "5050:80"
+  
+  the-gamers-network-OAuth2.0:
+    image: keycloak/keycloak:latest
+    container_name: tgn-development-oauth2
+    ports:
+      - "8080:8080"
+    env_file:
+      - "./development.env"
+    command: "start-dev"
+    volumes:
+      - oauth2:/var/lib/oauth2
 
 volumes:
   database:
+    driver: local
+  oauth2:
     driver: local


### PR DESCRIPTION
Added Keycloak in development mode to allow for integration of OAuth into the application.